### PR TITLE
Remove client argument from ui.Chat()

### DIFF
--- a/website/slides/slides-02.qmd
+++ b/website/slides/slides-02.qmd
@@ -885,7 +885,7 @@ app_ui = ui.page_fillable(
 
 def server(input, output, session):
     client = chatlas.ChatOpenAI()
-    chat = ui.Chat("chat", client)
+    chat = ui.Chat("chat")
 
     @chat.on_user_submit
     async def _(user_input: str):


### PR DESCRIPTION
The new ui.Chat() interface does not take client as an argument.

https://shiny.posit.co/py/docs/genai-chatbots.html